### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/TLDR/Constant.swift
+++ b/TLDR/Constant.swift
@@ -14,7 +14,7 @@ struct Repository {
     let name: String
     let branch: String
     
-    static let master = Repository(gitUrl: "https://github.com/", user: "tldr-pages", name: "tldr", branch: "master")
+    static let master = Repository(gitUrl: "https://github.com/", user: "tldr-pages", name: "tldr", branch: "main")
 }
 
 struct Constant {


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the `master` branch in favor of the `main` branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).